### PR TITLE
Zendesk Channel for Apple Business Chat support

### DIFF
--- a/temba/channels/types/zendesk/__init__.py
+++ b/temba/channels/types/zendesk/__init__.py
@@ -1,0 +1,2 @@
+
+from .type import ZendeskType  # noqa

--- a/temba/channels/types/zendesk/tests.py
+++ b/temba/channels/types/zendesk/tests.py
@@ -1,0 +1,54 @@
+
+from mock import patch
+
+from django.urls import reverse
+
+from temba.tests import MockResponse, TembaTest
+from temba.utils import json
+
+from ...models import Channel
+
+
+class ZendeskTypeTest(TembaTest):
+    def setUp(self):
+        super().setUp()
+
+        self.channel = Channel.create(
+            self.org,
+            self.user,
+            None,
+            "ABC",
+            name="Zendesk",
+            address="87654",
+            role="SR",
+            schemes=["zendesk"],
+            config={"FCM_TITLE": "Title", "FCM_KEY": "87654"},
+        )
+
+    @patch("requests.get")
+    def test_claim(self, mock_get):
+        url = reverse("channels.types.firebase.claim")
+
+        self.login(self.admin)
+
+        # check that claim page URL appears on claim list page
+        response = self.client.get(reverse("channels.channel_claim"))
+        self.assertContains(response, url)
+
+        mock_get.return_value = MockResponse(
+            200, json.dumps({"title": "FCM Channel", "key": "abcde12345", "send_notification": "True"})
+        )
+        response = self.client.post(
+            url, {"title": "FCM Channel", "key": "abcde12345", "send_notification": "True"}, follow=True
+        )
+
+        channel = Channel.objects.get(address="abcde12345")
+        self.assertRedirects(response, reverse("channels.channel_configuration", args=[channel.uuid]))
+        self.assertEqual(channel.channel_type, "FCM")
+        self.assertEqual(
+            channel.config, {"FCM_KEY": "abcde12345", "FCM_TITLE": "FCM Channel", "FCM_NOTIFICATION": True}
+        )
+
+        response = self.client.get(reverse("channels.channel_configuration", args=[channel.uuid]))
+        self.assertContains(response, reverse("courier.fcm", args=[channel.uuid, "receive"]))
+        self.assertContains(response, reverse("courier.fcm", args=[channel.uuid, "register"]))

--- a/temba/channels/types/zendesk/type.py
+++ b/temba/channels/types/zendesk/type.py
@@ -1,0 +1,48 @@
+
+from django.utils.translation import ugettext_lazy as _
+
+from temba.contacts.models import ZENDESK_SCHEME
+
+from ...models import ChannelType
+from .views import ClaimView
+
+
+class ZendeskType(ChannelType):
+    """
+    An Zendesk channel
+    """
+
+    code = "ZD"
+    category = ChannelType.Category.API
+
+    courier_url = r"^abc/(?P<uuid>[a-z0-9\-]+)/receive$"
+
+
+
+    name = "Zendesk"
+    icon = "icon-fcm"
+
+    claim_blurb = _(
+        """Connect your approved <a href="https://www.zendesk.com/" target="_blank">Zendesk</a> app"""
+    )
+    claim_view = ClaimView
+
+    schemes = [ZENDESK_SCHEME]
+    attachment_support = True
+    free_sending = True
+
+    configuration_blurb = _(
+        """
+        To use your Zendesk channel you'll have to configure the Zendesk server to direct messages to the url below.
+        """
+    )
+
+    configuration_urls = (
+        dict(
+            label=_("Receive URL"),
+            url="https://{{ channel.callback_domain }}{% url 'courier.abc' channel.uuid %}",
+            description=_(
+                "POST Zendesk trigger to this address."
+            ),
+        ),
+    )

--- a/temba/channels/types/zendesk/type.py
+++ b/temba/channels/types/zendesk/type.py
@@ -15,7 +15,7 @@ class ZendeskType(ChannelType):
     code = "ZD"
     category = ChannelType.Category.API
 
-    courier_url = r"^abc/(?P<uuid>[a-z0-9\-]+)/receive$"
+    courier_url = r"^zd/(?P<uuid>[a-z0-9\-]+)/receive$"
 
 
 
@@ -40,7 +40,7 @@ class ZendeskType(ChannelType):
     configuration_urls = (
         dict(
             label=_("Receive URL"),
-            url="https://{{ channel.callback_domain }}{% url 'courier.abc' channel.uuid %}",
+            url="https://{{ channel.callback_domain }}{% url 'courier.zd' channel.uuid %}",
             description=_(
                 "POST Zendesk trigger to this address."
             ),

--- a/temba/channels/types/zendesk/views.py
+++ b/temba/channels/types/zendesk/views.py
@@ -1,0 +1,47 @@
+
+
+from smartmin.views import SmartFormView
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from ...models import Channel
+from ...views import ClaimViewMixin
+
+
+class ClaimView(ClaimViewMixin, SmartFormView):
+    class Form(ClaimViewMixin.Form):
+        title = forms.CharField(required=True, label=_("Apple Business Chat Environment Title"), help_text=_("The name of your environment"))
+
+        business_id = forms.CharField(
+            required=True, label=_("Apple Business ID"), help_text=_("The business id provided by Apple.")
+        )
+        csp_id = forms.CharField(
+            required=True, label=_("Apple CSP ID"), help_text=_("The CSP id provided by Apple.")
+        )
+        secret_key = forms.CharField(
+            required=True,
+            label=_("Apple Secret Key"),
+            help_text=_("The secret key provided by apple"),
+        )
+
+    form_class = Form
+
+    def form_valid(self, form):
+        org = self.request.user.get_org()
+
+        title = form.cleaned_data.get("title")
+        password = form.cleaned_data.get("password")
+        username = form.cleaned_data.get("username")
+        base_url = form.cleaned_data.get("base_url")
+        config = {
+            Channel.CONFIG_USERNAME: username,
+            Channel.CONFIG_PASSWORD: password,
+            Channel.CONFIG_BASE_URL: base_url,
+        }
+
+        self.object = Channel.create(
+            org, self.request.user, None, self.channel_type, name=title, config=config
+        )
+
+        return super().form_valid(form)

--- a/temba/channels/types/zendesk/views.py
+++ b/temba/channels/types/zendesk/views.py
@@ -11,18 +11,18 @@ from ...views import ClaimViewMixin
 
 class ClaimView(ClaimViewMixin, SmartFormView):
     class Form(ClaimViewMixin.Form):
-        title = forms.CharField(required=True, label=_("Apple Business Chat Environment Title"), help_text=_("The name of your environment"))
+        title = forms.CharField(required=True, label=_("Zendesk Environment Title"), help_text=_("The name of your environment"))
 
-        business_id = forms.CharField(
-            required=True, label=_("Apple Business ID"), help_text=_("The business id provided by Apple.")
-        )
-        csp_id = forms.CharField(
-            required=True, label=_("Apple CSP ID"), help_text=_("The CSP id provided by Apple.")
-        )
-        secret_key = forms.CharField(
+        base_url = forms.CharField(
             required=True,
-            label=_("Apple Secret Key"),
-            help_text=_("The secret key provided by apple"),
+            label=_("Zendesk Base URL / Subdomain"),
+            help_text=_("Your zendesk subdomain https://mycompany.zendesk.com"),
+        )
+        username = forms.CharField(
+            required=True, label=_("Zendesk Account Username"), help_text=_("The API user's email address.")
+        )
+        auth_token = forms.CharField(
+            required=True, label=_("Zendesk API Auth Token"), help_text=_("The API auth token.")
         )
 
     form_class = Form
@@ -31,12 +31,12 @@ class ClaimView(ClaimViewMixin, SmartFormView):
         org = self.request.user.get_org()
 
         title = form.cleaned_data.get("title")
-        password = form.cleaned_data.get("password")
         username = form.cleaned_data.get("username")
+        auth_token = form.cleaned_data.get("auth_token")
         base_url = form.cleaned_data.get("base_url")
         config = {
             Channel.CONFIG_USERNAME: username,
-            Channel.CONFIG_PASSWORD: password,
+            Channel.CONFIG_AUTH_TOKEN: auth_token,
             Channel.CONFIG_BASE_URL: base_url,
         }
 

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -62,6 +62,7 @@ VIBER_SCHEME = "viber"
 FCM_SCHEME = "fcm"
 WHATSAPP_SCHEME = "whatsapp"
 WECHAT_SCHEME = "wechat"
+ZENDESK_SCHEME = "zendesk"
 
 FACEBOOK_PATH_REF_PREFIX = "ref:"
 
@@ -80,6 +81,7 @@ URN_SCHEME_CONFIG = (
     (WECHAT_SCHEME, _("WeChat identifier"), WECHAT_SCHEME),
     (FCM_SCHEME, _("Firebase Cloud Messaging identifier"), FCM_SCHEME),
     (WHATSAPP_SCHEME, _("WhatsApp identifier"), WHATSAPP_SCHEME),
+    (ZENDESK_SCHEME, _("Zendesk identifier"), ZENDESK_SCHEME),
 )
 
 
@@ -340,6 +342,10 @@ class URN(object):
     @classmethod
     def from_fcm(cls, path):
         return cls.from_parts(FCM_SCHEME, path)
+
+    @classmethod
+    def from_zendesk(cls, path):
+        return cls.from_parts(ZENDESK_SCHEME, path)
 
     @classmethod
     def from_jiochat(cls, path):
@@ -2375,6 +2381,7 @@ class ContactURN(models.Model):
         TELEGRAM_SCHEME: 90,
         VIBER_SCHEME: 90,
         FCM_SCHEME: 90,
+        ZENDESK_SCHEME: 90,
     }
 
     ANON_MASK = "*" * 8  # Returned instead of URN values for anon orgs

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from temba.campaigns.models import EventFire
 from temba.contacts.models import (
+    ZENDESK_SCHEME,
     EMAIL_SCHEME,
     EXTERNAL_SCHEME,
     FACEBOOK_SCHEME,
@@ -33,6 +34,7 @@ URN_SCHEME_ICONS = {
     LINE_SCHEME: "icon-line",
     EXTERNAL_SCHEME: "icon-channel-external",
     FCM_SCHEME: "icon-fcm",
+    ZENDESK_SCHEME: "icon-fcm",
 }
 
 ACTIVITY_ICONS = {

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -1046,6 +1046,7 @@ CHANNEL_TYPES = [
     "temba.channels.types.yo.YoType",
     "temba.channels.types.zenvia.ZenviaType",
     "temba.channels.types.i2sms.I2SMSType",
+    "temba.channels.types.zendesk.ZendeskType",
 ]
 
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Creates a new channel/addon for zendesk support tickets.

## Dev Testing Instructions
- Add a new channel, and save the `receive` url
- start the `courier` server (port 8080 by default), sharing the same `COURIER_DB`
- Substitue localhost:8080 for the rapidpro url, using the generated guid
  ```bash
  curl -v -XPOST -H "Content-type: application/json" -d '{
  "id": "4",
  "title": "hey its BC on the Sandboxed account now! testing if this went through",
  "comment": "message to local test",
  "attachments": [],
  "requester_id": "372518027891",
  "requester_name": "Apple Business Chat User urn:mbid:AQAAY1cfW9pjMDJ…"
  }' http://127.0.0.1:8080/c/zd/e2ee5364-b044-42a2-a226-739a4fc6ca67/receive
  ```
